### PR TITLE
Implemented the ability to track each step taken by any primary.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ include_directories(${ROOT_INCLUDE_DIR})
 ROOT_GENERATE_DICTIONARY(${CMAKE_CURRENT_BINARY_DIR}/HMolPolDict
   ${CMAKE_CURRENT_SOURCE_DIR}/include/HMolPolEventUnits.hh
   ${CMAKE_CURRENT_SOURCE_DIR}/include/HMolPolEventPrimary.hh
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/HMolPolEventPrimaryHit.hh
   ${CMAKE_CURRENT_SOURCE_DIR}/include/HMolPolEventGenericDetector.hh
   ${CMAKE_CURRENT_SOURCE_DIR}/include/HMolPolEventGenericDetectorHit.hh
   ${CMAKE_CURRENT_SOURCE_DIR}/include/HMolPolRunInformation.hh

--- a/HMolPol.cc
+++ b/HMolPol.cc
@@ -111,7 +111,9 @@ int main (int argc, char** argv)
   runManager->SetUserInitialization(myHMolPolDetector);
 
   // Register the Stepping Action (called at each step)
-  runManager->SetUserAction( new HMolPolSteppingAction() );
+  HMolPolSteppingAction *myHMolPolStepping =
+    new HMolPolSteppingAction(myHMolPolAnalysis);
+  runManager->SetUserAction( myHMolPolStepping );
 
   // Register the Stacking Action (called at each new particle created)
   HMolPolStackingAction *myHMolPolStacking = new HMolPolStackingAction();
@@ -156,7 +158,8 @@ int main (int argc, char** argv)
       myHMolPolRunAction,
       myHMolPolEventAction,
       myHMolPolAnalysis,
-      myHMolPolDetector);
+      myHMolPolDetector,
+      myHMolPolStepping);
 
   /*******
    * Initialize Run manager

--- a/include/HMolPolAnalysis.hh
+++ b/include/HMolPolAnalysis.hh
@@ -47,6 +47,7 @@ class HMolPolRunInformation;
 class HMolPolMessenger;
 class HMolPolEventPrimary;
 class HMolPolEventUnits;
+class HMolPolEventPrimaryHit;
 
 class HMolPolAnalysis
 {
@@ -125,6 +126,12 @@ class HMolPolAnalysis
     /// will contain the strings 'Detector1' and 'Detector2'. That's all this
     /// vector does: store the name of the branches in the ROOT file.
     std::vector<G4String> fDetectorName;
+
+    /// Primary tracks get their own branch in the ROOT tree. This holds all
+    /// the associated hits (each corresponding to a step)
+    std::vector<HMolPolEventPrimaryHit> *fPrimaryHits;
+    /// And its corresponding branch in the ROOT tree
+    TBranch *fPrimaryHitsBranch;
 
   private:
 

--- a/include/HMolPolEventLinkDef.hh
+++ b/include/HMolPolEventLinkDef.hh
@@ -26,6 +26,8 @@
 
 #pragma link C++ class HMolPolEventUnits+;
 #pragma link C++ class HMolPolEventPrimary+;
+#pragma link C++ class HMolPolEventPrimaryHit+;
+#pragma link C++ class std::vector<HMolPolEventPrimaryHit>+;
 #pragma link C++ class HMolPolEventGenericDetector+;
 #pragma link C++ class HMolPolEventGenericDetectorHit+;
 

--- a/include/HMolPolEventPrimaryHit.hh
+++ b/include/HMolPolEventPrimaryHit.hh
@@ -1,0 +1,31 @@
+/*****************************************
+ * Information of each step taken by a primary
+ ****************************************/
+#ifndef HMOLPOLEVENTPRIMARYHIT_HH_
+#define HMOLPOLEVENTPRIMARYHIT_HH_
+
+// ROOT includes
+#include <TObject.h>
+#include <TVector3.h>
+
+class HMolPolEventPrimaryHit: public TObject {
+  public:
+    HMolPolEventPrimaryHit() { };  ///< Constructor for
+      /// HMolPolEventPrimaryHit
+    virtual ~HMolPolEventPrimaryHit() { };  ///< Destrutor for
+    /// HMolPolEventPrimaryHit
+
+    Int_t fPrimaryID;   ///< Primary ID
+    TString fVolumeName; ///< The physical volume name where primary stepped
+
+    TVector3 fPosition; ///< Current primary position
+    TVector3 fMomentum; ///< Current primary momentum
+
+    /// Register this class with ROOT. This adds some standard ROOT functions to
+    /// the class, and makes sure that on the command line in ROOT it can do
+    /// tab-completion. This is associated with the ClassImp() line at the top
+    /// of the .cc file.
+    ClassDef(HMolPolEventPrimaryHit,1)
+};
+
+#endif /* HMOLPOLEVENTPRIMARYHIT_HH_ */

--- a/include/HMolPolMessenger.hh
+++ b/include/HMolPolMessenger.hh
@@ -32,6 +32,7 @@ class HMolPolRunAction;
 class HMolPolEventAction;
 class HMolPolAnalysis;
 class HMolPolDetectorConstruction;
+class HMolPolSteppingAction;
 
 class HMolPolMessenger : public G4UImessenger
 {
@@ -42,7 +43,8 @@ class HMolPolMessenger : public G4UImessenger
         HMolPolRunAction*,
         HMolPolEventAction*,
         HMolPolAnalysis*,
-        HMolPolDetectorConstruction*);   ///< constructor of the HMolPolMessenger
+        HMolPolDetectorConstruction*,
+        HMolPolSteppingAction*);   ///< constructor of the HMolPolMessenger
     virtual ~HMolPolMessenger();   ///< destructor of the HMolPolMessenger
 
     void SetNewValue(G4UIcommand* cmd, G4String newValue);   ///< function to
@@ -61,6 +63,9 @@ class HMolPolMessenger : public G4UImessenger
       /// to the Analysis class
     HMolPolDetectorConstruction*        fDetectorConstruction; ///< pointer
       /// to the DetectorConstruction class
+
+    HMolPolSteppingAction*              fSteppingAction; ///< pointer to the
+     /// SteppingAction class
 
     //Create different directories
       //These directories are the
@@ -84,6 +89,10 @@ class HMolPolMessenger : public G4UImessenger
 /// Geometry related variables
     G4UIdirectory*        fGeometryDir;       ///< create the Geometry Directory
     G4UIcmdWithAString*   fGeometryFileNameCmd;  ///< Geometry File Name
+
+/// Tracking/Step related variables
+    G4UIdirectory*        fTrackingDir;      ///< create Tracking directory
+    G4UIcmdWithABool*     fTrackPrimariesCmd; ///< Should primaries be tracked?
 };
 
 #endif // HMOLPOLMESSENGER_HH_

--- a/include/HMolPolPrimaryHit.hh
+++ b/include/HMolPolPrimaryHit.hh
@@ -1,0 +1,89 @@
+#ifndef HMolPolPrimaryHit_hh
+#define HMolPolPrimaryHit_hh
+
+//Geant4 includes
+
+#include <CLHEP/Vector/ThreeVector.h>
+#include <G4String.hh>
+#include <G4THitsCollection.hh>
+#include <G4Allocator.hh>
+#include <G4ThreeVector.hh>
+#include <G4Types.hh>
+#include <G4VHit.hh>
+
+// user includes
+
+class HMolPolPrimaryHit: public G4VHit {
+  public:
+    HMolPolPrimaryHit();  ///< Default constructor
+    HMolPolPrimaryHit(const HMolPolPrimaryHit& right); ///< Copy constructor
+    virtual ~HMolPolPrimaryHit(); //< Default destructor
+
+    // New and delete operators for custom allocator
+    inline void *operator new(size_t);
+    inline void operator delete(void *aHit);
+    void *operator new(size_t,void*p) { return p; }
+
+    const G4ThreeVector& GetPosition() const {
+      return fPosition;
+    } ///< function to get the three vector of the position (is a constant)
+      // of the track
+
+    void SetPrimaryID( G4int id) {
+      fPrimaryID = id;
+    } ///< function to set the primary ID
+
+    G4int GetPrimaryID() {
+      return fPrimaryID;
+    } ///< function to get primary ID
+
+    void SetPosition(const G4ThreeVector& position) {
+      fPosition = position;
+    } ///< function to set the three vector of the position (is a constant)
+    // of the track
+
+    const G4ThreeVector& GetMomentum() const {
+      return fMomentum;
+    } ///< function to get the three vector of the momentum (is a constant)
+    // of the track
+
+    void SetMomentum(const G4ThreeVector& momentum) {
+      fMomentum = momentum;
+    } ///< function to set the three vector of the momentum (is a constant)
+    // of the track
+
+    G4String GetVolumeName() {
+      return fVolumeName;
+    } ///< function to get the physical volume name
+
+    void SetVolumeName(G4String VolumeName) {
+      fVolumeName = VolumeName;
+    } ///< function to set the physical volume name
+
+  private:
+    G4int fPrimaryID; ///< ID of this primary
+    G4String fVolumeName; ///< Name of the physical volume
+    G4ThreeVector fPosition; ///< the position of the track
+    G4ThreeVector fMomentum; ///< the momentum of the track
+};
+
+
+/// Define special HitCollection (vector) of Primary Hits type
+typedef G4THitsCollection<HMolPolPrimaryHit> HMolPolPrimaryHitsCollection;
+
+/// A generic allocator of Primary Hits
+extern G4Allocator<HMolPolPrimaryHit> HMolPolPrimaryHitAllocator;
+
+/// Operator to create a new hit (for use with the custom allocator)
+inline void* HMolPolPrimaryHit::operator new(size_t){
+    void *aHit;
+    aHit = (void *) HMolPolPrimaryHitAllocator.MallocSingle();
+    return aHit;
+}
+
+/// Operator to delete a hit (for use with the custom allocator)
+inline void HMolPolPrimaryHit::operator delete(void *aHit){
+    HMolPolPrimaryHitAllocator.FreeSingle( (HMolPolPrimaryHit*) aHit);
+}
+
+#endif // HMolPolPrimaryHit_hh

--- a/include/HMolPolSteppingAction.hh
+++ b/include/HMolPolSteppingAction.hh
@@ -6,15 +6,21 @@
 
 #include <G4UserSteppingAction.hh>
 #include <G4Types.hh>
+class HMolPolAnalysis;
 
 class HMolPolSteppingAction: public G4UserSteppingAction {
   public:
-    HMolPolSteppingAction();
+    HMolPolSteppingAction( HMolPolAnalysis *analysis );
     virtual ~HMolPolSteppingAction() {};
     void UserSteppingAction(const G4Step* step);
+    void SetTrackPrimaries(G4bool trackPrimaries) {
+      fTrackPrimaries = trackPrimaries;
+    }
 
   private:
+    HMolPolAnalysis *fAnalysis; ///< Pointer to the Analysis instance
     G4double fMaxTransportTime; ///< Max transportation time before track is killed
+    G4bool   fTrackPrimaries;   ///< Flag to track primaries or not primary hits.
 };
 
 #endif /* HMOLPOLSTEPPINGACTION_HH_ */

--- a/src/HMolPolAnalysis.cc
+++ b/src/HMolPolAnalysis.cc
@@ -24,6 +24,7 @@
 #include "HMolPolEventPrimary.hh"
 #include "HMolPolEventGenericDetector.hh"
 #include "HMolPolRunInformation.hh"
+#include "HMolPolEventPrimaryHit.hh"
 
 /// \todo make this so the file names can change with things like generator etc
 /// ie HMolPol_eleastic HMolPol_Moller, etc
@@ -232,6 +233,11 @@ void HMolPolAnalysis::ConstructRootTree()
     fDetectorBranch[i] = fRootTree->Branch(TString("f") + TString(fDetectorName[i]),
         "HMolPolEventGenericDetector", &fDetector[i], bufsize, split);
   }
+
+  // Add the primary hits branch
+  fPrimaryHits = new std::vector<HMolPolEventPrimaryHit>();
+  fRootTree->Branch("PrimaryTracker","std::vector<HMolPolEventPrimaryHit>",
+      &fPrimaryHits, bufsize, split);
 
   // Write run data
   pRunInformation->Write();

--- a/src/HMolPolEventAction.cc
+++ b/src/HMolPolEventAction.cc
@@ -30,6 +30,7 @@
 #include "HMolPolStackingAction.hh"
 #include "HMolPolEventGenericDetector.hh"
 #include "HMolPolGenericDetectorHit.hh"
+#include "HMolPolEventPrimaryHit.hh"
 
 /********************************************
  * Programmer: Valerie Gray
@@ -92,6 +93,9 @@ void HMolPolEventAction::BeginOfEventAction(const G4Event* event)
 
   // Ask StackingAction to prepare for new event
   fStacking->InitNewEvent();
+
+  // Clean up old primary hits
+  fAnalysis->fPrimaryHits->clear();
 
 /*
 /// \bug not sure what this does at this point forward - it is unused!?!

--- a/src/HMolPolEventPrimaryHit.cc
+++ b/src/HMolPolEventPrimaryHit.cc
@@ -1,0 +1,7 @@
+#include "HMolPolEventPrimaryHit.hh"
+
+/// Register this class with ROOT. This adds some standard ROOT functions to
+/// the class, and makes sure that on the command line in ROOT it can do
+/// tab-completion. This is associated with the ClassDef() line at the end
+/// of the class definition in the .hh file.
+ClassImp(HMolPolEventPrimaryHit)

--- a/src/HMolPolMessenger.cc
+++ b/src/HMolPolMessenger.cc
@@ -33,6 +33,7 @@
 #include "HMolPolAnalysis.hh"
 #include "HMolPolMessenger.hh"
 #include "HMolPolDetectorConstruction.hh"
+#include "HMolPolSteppingAction.hh"
 
 //standard includes
 #include <iostream>
@@ -59,12 +60,14 @@ HMolPolMessenger::HMolPolMessenger(
     HMolPolRunAction* runAction,
     HMolPolEventAction* eventAction,
     HMolPolAnalysis* analysis,
-    HMolPolDetectorConstruction* detectorConstruction)
+    HMolPolDetectorConstruction* detectorConstruction,
+    HMolPolSteppingAction* steppingAction)
 : fPrimaryGeneratorAction(primaryGeneratorAction),  //initialize variables
   fRunAction(runAction),
   fEventAction(eventAction),
   fAnalysis(analysis),
-  fDetectorConstruction(detectorConstruction)
+  fDetectorConstruction(detectorConstruction),
+  fSteppingAction(steppingAction)
 {
   //------------------------------------------------------------------------------
   // create a new directory for all the analysis related stuff
@@ -114,6 +117,17 @@ HMolPolMessenger::HMolPolMessenger(
     new G4UIcmdWithAString("/HMolPol/Geometry/GeometryFileName",this);
   fGeometryFileNameCmd->SetGuidance("File Name and path of Geometry GDML file");
   fGeometryFileNameCmd->SetParameterName("GeometryFileName",false);
+
+  // Directory for all Tracking/Step related commands
+  fTrackingDir = new G4UIdirectory("/HMolPol/Tracking/");
+  fTrackingDir->SetGuidance("HMolPol Tracking control");
+
+  // Enable primary tracker? (tracks and stores all steps taken by a primary)
+  fTrackPrimariesCmd =
+    new G4UIcmdWithABool("/HMolPol/Tracking/TrackPrimaries",this);
+  fTrackPrimariesCmd->SetGuidance("Track and store all steps of primaries?");
+  fTrackPrimariesCmd->SetParameterName("TrackPrimaries",false);
+
 }
 
 /********************************************
@@ -227,6 +241,15 @@ void HMolPolMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
     G4cout << "#### Messenger: Setting Geometry file to "
         << newValue << G4endl;
     fDetectorConstruction->SetGeometryFileName(newValue);
+  }
+
+  // Track Primaries command
+  if( command == fTrackPrimariesCmd )
+  {
+    G4cout << "#### Messenger: Setting Tracking Primaries to "
+        << newValue << G4endl;
+    fSteppingAction->SetTrackPrimaries(
+        fTrackPrimariesCmd->GetNewBoolValue(newValue));
   }
 
   return;

--- a/src/HMolPolPrimaryHit.cc
+++ b/src/HMolPolPrimaryHit.cc
@@ -1,0 +1,50 @@
+// Generic Primary Hit class loosely based on HMolPolGenericDetectorHit
+
+// geant4 includes
+#include "G4VVisManager.hh"
+#include "G4VisAttributes.hh"
+#include "G4Circle.hh"
+#include "G4Color.hh"
+
+// user includes
+#include "HMolPolPrimaryHit.hh"
+
+/// Hit allocator instance
+G4Allocator<HMolPolPrimaryHit> HMolPolPrimaryHitAllocator;
+
+/********************************************
+ * Default constructor
+ *
+ * Initialize a new instance of a Primary Hit
+ *
+ ********************************************/
+HMolPolPrimaryHit::HMolPolPrimaryHit()
+{
+  fVolumeName = "NULL";
+  fPosition = G4ThreeVector(0.0,0.0,0.0);
+  fMomentum = G4ThreeVector(0.0,0.0,0.0);
+}
+
+/********************************************
+ * Copy constructor
+ *  -- copies contents from passed instance of primary hit class.
+ *
+ ********************************************/
+HMolPolPrimaryHit::HMolPolPrimaryHit(const HMolPolPrimaryHit& right)
+{
+  //debugging
+  G4cout << G4endl << "# In the HMolPolPrimaryHit::HMolPolPrimaryHit #"<< G4endl;
+  G4cout << "Copy constructor for HMolPolPrimaryHit called" << G4endl;
+
+  fVolumeName = right.fVolumeName;
+  fPosition     = right.fPosition;
+  fMomentum     = right.fMomentum;
+}
+
+/********************************************
+ * Default destructor
+ ********************************************/
+HMolPolPrimaryHit::~HMolPolPrimaryHit()
+{
+
+}

--- a/src/HMolPolSteppingAction.cc
+++ b/src/HMolPolSteppingAction.cc
@@ -1,4 +1,6 @@
 #include "HMolPolSteppingAction.hh"
+#include "HMolPolEventPrimaryHit.hh"
+#include "HMolPolAnalysis.hh"
 #include <G4Track.hh>
 
 
@@ -6,10 +8,9 @@
  * TODO: Max transportation time should be configurable through the messenger
  * class.
  */
-HMolPolSteppingAction::HMolPolSteppingAction() :
-  fMaxTransportTime(1*CLHEP::s)
+HMolPolSteppingAction::HMolPolSteppingAction( HMolPolAnalysis *analysis) :
+  fAnalysis(analysis), fMaxTransportTime(1*CLHEP::s), fTrackPrimaries(true)
 {
-
 }
 
 /*
@@ -24,5 +25,21 @@ void HMolPolSteppingAction::UserSteppingAction(const G4Step* step)
     G4cerr << "Particle time too long, forced stop." << G4endl;
     track->SetTrackStatus(fStopAndKill);
   }
-  return;
+
+  // Should primaries be tracked at every step?
+  if(fTrackPrimaries && track->GetParentID() == 0)
+  {
+    HMolPolEventPrimaryHit hit;
+    hit.fPrimaryID = track->GetTrackID();
+    hit.fVolumeName = track->GetVolume()->GetName();
+    hit.fPosition = TVector3(
+        track->GetPosition().x(),
+        track->GetPosition().y(),
+        track->GetPosition().z());
+    hit.fMomentum = TVector3(
+        track->GetMomentum().x(),
+        track->GetMomentum().y(),
+        track->GetMomentum().z());
+    fAnalysis->fPrimaryHits->push_back(hit);
+  }
 }


### PR DESCRIPTION
It stores the result in a new branch on the tree called PrimaryTracker.

Tracking is on by default, but can be turned off with the command
/HMolPol/Tracking/TrackPrimaries false
